### PR TITLE
Fix context error

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,10 +20,9 @@ exports.createPages = ({ graphql, actions }) => {
     }
   `).then(result => {
     result.data.allWordpressPost.edges.forEach(({ node }) => {
-      console.log('create page!', node.slug);
       createPage({
         path: node.slug,
-        component: path.resolve(`./src/pages/post.jsx`),
+        component: path.resolve(`./src/templates/post.jsx`),
         context: {
           // Data passed to context is available
           // in page queries as GraphQL variables.

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -10,6 +10,7 @@ class Post extends Component {
 
     return (
       <Layout>
+        <p>Hello</p>
         <SEO title={title} keywords={[`gatsby`, `application`, `react`]} />
         <h1
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
Fixes an error caused when an empty context is passed from `gatsby-node.js`. This was because `createPages` was being run on other non-WP pages in the `/pages` folder. 

![image](https://user-images.githubusercontent.com/351842/56073435-d5226700-5d71-11e9-849e-206847779173.png)

from https://github.com/gatsbyjs/gatsby/issues/10742#issuecomment-464520218. 
