### PR TITLE
Add .env.production to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ yarn-error.log
 .yarn-integrity
 
 .env.development
+.env.production


### PR DESCRIPTION
This is so `gatsby build` can run properly locally. 